### PR TITLE
Can now handle specifying snapshots by tag (or multiple tags) instead of using the volume ids.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ say, every hour, then run this script periodically to clean up.
 
         hours -> days -> weeks -> months
 
-    MANDATORY options:
+    MANDATORY options (one of -v or -t must be used):
         -v, --volumes VOL1,VOL2,...      Comma-separated list (no spaces) of volume-ids,
                                          or 'all' for all volumes
+        -t, --tag KEY=VALUE              Tag to use to filter the snapshot. May specify multiple tags.
 
     MANDATORY rules:
         -h, --hours HOURS                The number of hours to keep ALL snapshots


### PR DESCRIPTION
This allows a configuration where there is a single instance which may be re-initialized from a new base image
with new volumes built from old snapshots. The volume id changes but taking a snapshot with the same tags allows this script to purge the snapshots as if they were from a single volume. See [Keeping an Amazon EC2 Instance Up with Chef and Auto-Scaling](http://www.trailhunger.com/blog/technical/2011/05/28/keeping-an-amazon-elastic-compute-cloud-ec2-instance-up-with-chef-and-auto-scaling/) for more information.
