### PR TITLE
Localtime

### DIFF
--- a/ec2-purge-snapshots.rb
+++ b/ec2-purge-snapshots.rb
@@ -17,7 +17,7 @@ def purge_snapshots(ec2, options, vol, vol_snaps, volume_counts)
   keep_count      = 0
 
   vol_snaps.each do |snap|
-    snap_date = Time.parse(snap['startTime'])
+    snap_date = Time.parse(snap['startTime']).localtime
     snap_Date = Date.parse(snap_date.to_s)
     snap_age = ((NOW.to_i - snap_date.to_i).to_f / HOUR.to_f).to_i
     # Hourly 


### PR DESCRIPTION
This small change will calculate the snapshot start datetime according
to the local time of the server where this is run.  By default, all
snapshots are done in UTC, which means the daily snapshots that it
saves will be at midnight UTC.  WIth this change the daily snapshots
that are kept will be at midnight localtime.

This is necessary because the snap_age is calculated by taking the
Time.now function minus the snap startTime.  If the server this is run
from is set to a timezone other than UTC, then this will give a skewed
snap age.  This fix accounts for that.
